### PR TITLE
Fix jruby-win32 dependencies

### DIFF
--- a/logstash-input-wmi.gemspec
+++ b/logstash-input-wmi.gemspec
@@ -23,10 +23,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
 
   if RUBY_PLATFORM == 'java'
-    s.add_runtime_dependency 'jruby-win32ole'
-  else
-    s.add_runtime_dependency 'win32ole'
+    s.platform = RUBY_PLATFORM
+    s.add_runtime_dependency "jruby-win32ole"                   #(unknown license)
   end
-
 end
 

--- a/spec/inputs/wmi_spec.rb
+++ b/spec/inputs/wmi_spec.rb
@@ -1,1 +1,5 @@
 require 'spec_helper'
+require 'logstash/inputs/wmi'
+
+describe LogStash::Inputs::WMI do
+end


### PR DESCRIPTION
You need to force the current platform before requiring the jruby-win32ole gem.
