### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/lib/logstash/inputs/wmi.rb
+++ b/lib/logstash/inputs/wmi.rb
@@ -55,7 +55,11 @@ class LogStash::Inputs::WMI < LogStash::Inputs::Base
           event["host"] = @host
           decorate(event)
           wmiobj.Properties_.each do |prop|
-            event[prop.name] = prop.value
+            if prop.value.is_a?(String)
+              event[prop.name] = prop.value.force_encoding(Encoding::UTF_8)
+            else
+              event[prop.name] = prop.value
+	    end
           end
           queue << event
 	  break if stop?

--- a/logstash-input-wmi.gemspec
+++ b/logstash-input-wmi.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM
     s.add_runtime_dependency "jruby-win32ole"                   #(unknown license)
+    s.add_runtime_dependency "stud", "~> 0.0.22"   # Apache 2.0 License
   end
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-plain'
 end
 

--- a/spec/inputs/wmi_spec.rb
+++ b/spec/inputs/wmi_spec.rb
@@ -1,5 +1,9 @@
+# encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require 'logstash/inputs/wmi'
 
 describe LogStash::Inputs::WMI, :windows => true do
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) { { "query" => "select * from Win32_Process", "interval" => 10 }}
+  end
 end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3895

resolves #10 
