### PR TITLE
Update plugin to the new event api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: false
+jdk:
+ - oraclejdk8
 language: ruby
 cache: bundler
 rvm:
-  - jruby-1.7.23
-script: 
-  - bundle exec rspec spec
+ - jruby-1.7.25
+script:
+ - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
-# 2.0.4
+## 3.0.0
+  - Relax constraints on the `logstash-core-plugin-api`
+  - Update plugin to the new event api
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/inputs/wmi.rb
+++ b/lib/logstash/inputs/wmi.rb
@@ -75,10 +75,10 @@ class LogStash::Inputs::WMI < LogStash::Inputs::Base
         @wmi.ExecQuery(@query).each do |wmiobj|
           # create a single event for all properties in the collection
           event = LogStash::Event.new
-          event["host"] = @host
+          event.set("host", @host)
           decorate(event)
           wmiobj.Properties_.each do |prop|
-            event[prop.name] = prop.value
+            event.set(prop.name, prop.value)
           end
           queue << event
         end

--- a/logstash-input-wmi.gemspec
+++ b/logstash-input-wmi.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-input-wmi'
-  s.version         = '2.0.5'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Collect data from WMI query"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM


### PR DESCRIPTION
- update travis.
- Relax constraints on the `logstash-core-plugin-api`
- Update plugin to the new event api